### PR TITLE
Fix the unused result warning, it breaks imports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(verushash STATIC
         )
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=x86-64")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -Wno-unused-result")
 
     # optimizations
     add_definitions(-O2)


### PR DESCRIPTION
Getting it into master on my fork so I can use it while playing with the gitlab CI stuff. The warning breaks the CI build.